### PR TITLE
[backplane] add overload manager

### DIFF
--- a/cmd/backplane/main.go
+++ b/cmd/backplane/main.go
@@ -87,6 +87,9 @@ var (
 
 	useEnvoyContrib = flag.Bool("use_envoy_contrib", false, "Use Envoy contrib filters.")
 
+	overloadMaxHeapSizeBytes       = flag.Uint64("overload-max-heap-size-bytes", 0, "Maximum heap size in bytes for Envoy overload manager.")
+	overloadMaxActiveConnections = flag.Uint64("overload-max-active-connections", 0, "Maximum number of active downstream connections for Envoy overload manager.")
+
 	k8sKVNamespace    = flag.String("k8s_kv_namespace", os.Getenv("POD_NAMESPACE"), "Namespace for the K/V store.")
 	k8sKVPeerSelector = flag.String("k8s_kv_peer_selector", "app.kubernetes.io/component=backplane", "Label selector for K/V store peers.")
 
@@ -282,6 +285,12 @@ func main() {
 	}
 	if *useEnvoyContrib {
 		proxyOpts = append(proxyOpts, bpctrl.WithEnvoyContrib())
+	}
+	if *overloadMaxHeapSizeBytes > 0 {
+		proxyOpts = append(proxyOpts, bpctrl.WithOverloadMaxHeapSizeBytes(*overloadMaxHeapSizeBytes))
+	}
+	if *overloadMaxActiveConnections > 0 {
+		proxyOpts = append(proxyOpts, bpctrl.WithOverloadMaxActiveConnections(*overloadMaxActiveConnections))
 	}
 	if *readyProbePort != 0 {
 		hc := healthchecker.NewAggregatedHealthChecker()

--- a/pkg/gateway/xds/bootstrap/bootstrap.go
+++ b/pkg/gateway/xds/bootstrap/bootstrap.go
@@ -140,10 +140,17 @@ type BootstrapConfig struct {
 }
 
 func defaultBootstrapConfig() *BootstrapConfig {
+	// Create a variable from the constant so we can take its address
+	defaultConnections := defaultEnvoyMaxActiveDownstreamConnections
+
+	// Get the default max heap size from the detector
+	maxHeapSize := GetDefaultMaxHeapSizeBytes()
+
 	return &BootstrapConfig{
 		XdsServerHost:                          envoyGatewayXdsServerHost,
 		XdsServerPort:                          DefaultXdsServerPort,
-		OverloadMaxActiveDownstreamConnections: &defaultEnvoyMaxActiveDownstreamConnections,
+		OverloadMaxHeapSizeBytes:               maxHeapSize,
+		OverloadMaxActiveDownstreamConnections: &defaultConnections,
 	}
 }
 

--- a/pkg/gateway/xds/bootstrap/cgroup_memory.go
+++ b/pkg/gateway/xds/bootstrap/cgroup_memory.go
@@ -1,0 +1,225 @@
+package bootstrap
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/apoxy-dev/apoxy/pkg/log"
+)
+
+// FileReader is an interface for reading files, used for testing
+type FileReader interface {
+	ReadFile(filename string) ([]byte, error)
+	Open(name string) (*os.File, error)
+}
+
+// DefaultFileReader is the default implementation of FileReader
+type DefaultFileReader struct{}
+
+// ReadFile reads a file using os.ReadFile
+func (r DefaultFileReader) ReadFile(filename string) ([]byte, error) {
+	return os.ReadFile(filename)
+}
+
+// Open opens a file using os.Open
+func (r DefaultFileReader) Open(name string) (*os.File, error) {
+	return os.Open(name)
+}
+
+// CgroupMemoryDetector detects cgroup memory limits
+type CgroupMemoryDetector struct {
+	fileReader FileReader
+	// cgroup paths
+	cgroupV1Path        string
+	cgroupV2Path        string
+	cgroupV2UnifiedPath string
+	cgroupV1ProcPath    string
+	cgroupV2ProcPath    string
+}
+
+// NewCgroupMemoryDetector creates a new CgroupMemoryDetector with default paths
+func NewCgroupMemoryDetector() *CgroupMemoryDetector {
+	return &CgroupMemoryDetector{
+		fileReader:          DefaultFileReader{},
+		cgroupV1Path:        "/sys/fs/cgroup/memory/memory.limit_in_bytes",
+		cgroupV2Path:        "/sys/fs/cgroup/memory.max",
+		cgroupV2UnifiedPath: "/sys/fs/cgroup/memory.max",
+		cgroupV1ProcPath:    "/proc/self/cgroup",
+		cgroupV2ProcPath:    "/proc/self/mountinfo",
+	}
+}
+
+// GetMemoryLimit returns the cgroup memory limit in bytes.
+// It tries to detect both cgroup v1 and v2 memory limits.
+// If no limit is found, it returns 0.
+func (d *CgroupMemoryDetector) GetMemoryLimit() uint64 {
+	// Try cgroup v2 first
+	memLimit, err := d.getCgroupV2MemoryLimit()
+	if err == nil && memLimit > 0 {
+		log.Infof("Successfully read cgroup v2 memory limit: %d bytes", memLimit)
+		return memLimit
+	}
+
+	// Fall back to cgroup v1
+	memLimit, err = d.getCgroupV1MemoryLimit()
+	if err == nil && memLimit > 0 {
+		log.Infof("Successfully read cgroup v1 memory limit: %d bytes", memLimit)
+		return memLimit
+	}
+
+	log.Infof("Could not detect cgroup memory limit, using default")
+	return 0
+}
+
+// GetDefaultMaxHeapSizeBytes returns the default max heap size in bytes based on cgroup memory limit
+func (d *CgroupMemoryDetector) GetDefaultMaxHeapSizeBytes() *uint64 {
+	memLimit := d.GetMemoryLimit()
+	if memLimit > 0 {
+		return &memLimit
+	}
+	return nil
+}
+
+// getCgroupV2MemoryLimit returns the cgroup v2 memory limit in bytes.
+func (d *CgroupMemoryDetector) getCgroupV2MemoryLimit() (uint64, error) {
+	// First try the unified hierarchy
+	content, err := d.fileReader.ReadFile(d.cgroupV2UnifiedPath)
+	if err == nil {
+		return d.parseCgroupMemoryValue(string(content))
+	}
+
+	// Try to find the cgroup path from mountinfo
+	cgroupPath, err := d.detectCgroupV2Path()
+	if err != nil {
+		return 0, err
+	}
+
+	// Read the memory.max file
+	memLimitPath := filepath.Join(cgroupPath, "memory.max")
+	content, err = d.fileReader.ReadFile(memLimitPath)
+	if err != nil {
+		return 0, err
+	}
+
+	return d.parseCgroupMemoryValue(string(content))
+}
+
+// getCgroupV1MemoryLimit returns the cgroup v1 memory limit in bytes.
+func (d *CgroupMemoryDetector) getCgroupV1MemoryLimit() (uint64, error) {
+	// First try the default path
+	content, err := d.fileReader.ReadFile(d.cgroupV1Path)
+	if err == nil {
+		return d.parseCgroupMemoryValue(string(content))
+	}
+
+	// Try to find the cgroup path from /proc/self/cgroup
+	cgroupPath, err := d.detectCgroupV1Path()
+	if err != nil {
+		return 0, err
+	}
+
+	// Read the memory.limit_in_bytes file
+	memLimitPath := filepath.Join("/sys/fs/cgroup/memory", cgroupPath, "memory.limit_in_bytes")
+	content, err = d.fileReader.ReadFile(memLimitPath)
+	if err != nil {
+		return 0, err
+	}
+
+	return d.parseCgroupMemoryValue(string(content))
+}
+
+// detectCgroupV1Path returns the cgroup path for the current process in cgroup v1.
+func (d *CgroupMemoryDetector) detectCgroupV1Path() (string, error) {
+	file, err := d.fileReader.Open(d.cgroupV1ProcPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(line, ":")
+		if len(parts) == 3 && strings.Contains(parts[1], "memory") {
+			return parts[2], nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("memory controller not found in cgroup v1")
+}
+
+// detectCgroupV2Path returns the cgroup path for the current process in cgroup v2.
+func (d *CgroupMemoryDetector) detectCgroupV2Path() (string, error) {
+	file, err := d.fileReader.Open(d.cgroupV2ProcPath)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		fields := strings.Fields(line)
+		if len(fields) >= 5 && fields[4] == "cgroup2" {
+			return fields[4], nil
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", fmt.Errorf("cgroup2 mount point not found")
+}
+
+// parseCgroupMemoryValue parses the memory value from cgroup files.
+// It handles "max" value (which means unlimited) and converts to uint64.
+func (d *CgroupMemoryDetector) parseCgroupMemoryValue(value string) (uint64, error) {
+	value = strings.TrimSpace(value)
+	if value == "max" {
+		return 0, nil // "max" means no limit
+	}
+
+	memLimit, err := strconv.ParseUint(value, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	// Sanity check: if the value is unreasonably large or small, ignore it
+	if memLimit < 1024*1024 || memLimit > 1024*1024*1024*1024 {
+		return 0, fmt.Errorf("memory limit value out of reasonable range: %d", memLimit)
+	}
+
+	return memLimit, nil
+}
+
+// MemoryDetector is an interface for memory limit detection
+type MemoryDetector interface {
+	GetMemoryLimit() uint64
+	GetDefaultMaxHeapSizeBytes() *uint64
+}
+
+// Global instance of the detector for convenience
+var defaultDetector MemoryDetector = NewCgroupMemoryDetector()
+
+// GetCgroupMemoryLimit returns the cgroup memory limit using the default detector
+func GetCgroupMemoryLimit() uint64 {
+	return defaultDetector.GetMemoryLimit()
+}
+
+// GetDefaultMaxHeapSizeBytes returns the default max heap size in bytes based on cgroup memory limit
+func GetDefaultMaxHeapSizeBytes() *uint64 {
+	memLimit := GetCgroupMemoryLimit()
+	if memLimit > 0 {
+		return &memLimit
+	}
+	return nil
+}

--- a/pkg/gateway/xds/bootstrap/cgroup_memory_test.go
+++ b/pkg/gateway/xds/bootstrap/cgroup_memory_test.go
@@ -1,0 +1,180 @@
+package bootstrap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MockFileReader implements FileReader for testing
+type MockFileReader struct {
+	files map[string][]byte
+}
+
+// ReadFile mocks reading a file
+func (r *MockFileReader) ReadFile(filename string) ([]byte, error) {
+	if content, ok := r.files[filename]; ok {
+		return content, nil
+	}
+	return nil, os.ErrNotExist
+}
+
+// Open is not implemented for the mock
+func (r *MockFileReader) Open(name string) (*os.File, error) {
+	return nil, os.ErrNotExist // Not needed for our tests
+}
+
+// mockDetector is a mock implementation for testing
+type mockDetector struct {
+	memLimit uint64
+}
+
+// GetMemoryLimit returns the mock memory limit
+func (d *mockDetector) GetMemoryLimit() uint64 {
+	return d.memLimit
+}
+
+// GetDefaultMaxHeapSizeBytes returns a fixed heap size for testing
+func (d *mockDetector) GetDefaultMaxHeapSizeBytes() *uint64 {
+	if d.memLimit > 0 {
+		// Use 80% of the memory limit as the max heap size
+		heapSize := uint64(float64(d.memLimit) * 0.8)
+		return &heapSize
+	}
+	return nil
+}
+
+func TestCgroupMemoryDetector_GetMemoryLimit(t *testing.T) {
+	// Create a mock file reader
+	mockReader := &MockFileReader{
+		files: make(map[string][]byte),
+	}
+
+	// Create a detector with the mock reader
+	detector := NewCgroupMemoryDetector()
+	detector.fileReader = mockReader
+
+	// Test cases
+	testCases := []struct {
+		name           string
+		setupFunc      func()
+		expectedResult uint64
+	}{
+		{
+			name: "cgroup v2 unified path",
+			setupFunc: func() {
+				// Clear previous test files
+				mockReader.files = make(map[string][]byte)
+				// Add mock cgroup v2 file
+				mockReader.files[detector.cgroupV2UnifiedPath] = []byte("2147483648\n")
+			},
+			expectedResult: 2147483648, // 2GB
+		},
+		{
+			name: "cgroup v1 path",
+			setupFunc: func() {
+				// Clear previous test files
+				mockReader.files = make(map[string][]byte)
+				// Add mock cgroup v1 file
+				mockReader.files[detector.cgroupV1Path] = []byte("1073741824\n")
+			},
+			expectedResult: 1073741824, // 1GB
+		},
+		{
+			name: "cgroup v2 max value (unlimited)",
+			setupFunc: func() {
+				// Clear previous test files
+				mockReader.files = make(map[string][]byte)
+				// Add mock cgroup v2 file with "max" value
+				mockReader.files[detector.cgroupV2UnifiedPath] = []byte("max\n")
+			},
+			expectedResult: 0, // "max" means no limit
+		},
+		{
+			name: "no cgroup files",
+			setupFunc: func() {
+				// Clear all files
+				mockReader.files = make(map[string][]byte)
+			},
+			expectedResult: 0, // No limit detected
+		},
+	}
+
+	// Run test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.setupFunc()
+			result := detector.GetMemoryLimit()
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestGetCgroupMemoryLimit(t *testing.T) {
+	// Save the original detector
+	origDetector := defaultDetector
+	defer func() { defaultDetector = origDetector }()
+
+	// Create a mock detector
+	mockReader := &MockFileReader{
+		files: map[string][]byte{
+			"/sys/fs/cgroup/memory.max": []byte("2147483648\n"),
+		},
+	}
+
+	mockDetector := NewCgroupMemoryDetector()
+	mockDetector.fileReader = mockReader
+
+	// Replace the default detector
+	defaultDetector = mockDetector
+
+	// Test the function
+	result := GetCgroupMemoryLimit()
+	assert.Equal(t, uint64(2147483648), result)
+}
+
+func TestGetDefaultMaxHeapSizeBytes(t *testing.T) {
+	// Save the original detector
+	origDetector := defaultDetector
+	defer func() { defaultDetector = origDetector }()
+
+	testCases := []struct {
+		name           string
+		memoryLimit    uint64
+		expectedResult *uint64
+	}{
+		{
+			name:        "with memory limit",
+			memoryLimit: 2147483648, // 2GB
+			expectedResult: func() *uint64 {
+				val := uint64(2147483648)
+				return &val
+			}(),
+		},
+		{
+			name:           "no memory limit",
+			memoryLimit:    0,
+			expectedResult: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a mock detector with a custom implementation
+			mockDetector := &mockDetector{
+				memLimit: tc.memoryLimit,
+			}
+			defaultDetector = mockDetector
+
+			result := GetDefaultMaxHeapSizeBytes()
+
+			if tc.expectedResult == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.NotNil(t, result)
+				assert.Equal(t, *tc.expectedResult, *result)
+			}
+		})
+	}
+}

--- a/pkg/gateway/xds/bootstrap/testdata/render/overload-manager-cgroup.yaml
+++ b/pkg/gateway/xds/bootstrap/testdata/render/overload-manager-cgroup.yaml
@@ -1,0 +1,106 @@
+admin:
+  access_log:
+  - name: envoy.access_loggers.file
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+      path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 19000
+layered_runtime:
+  layers:
+  - name: global_config
+    static_layer:
+      envoy.restart_features.use_eds_cache_for_ads: true
+      re2.max_program_size.error_level: 4294967295
+      re2.max_program_size.warn_level: 1000
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    transport_api_version: V3
+    grpc_services:
+    - envoy_grpc:
+        cluster_name: xds_cluster
+    set_node_on_first_message_only: true
+  lds_config:
+    ads: {}
+    resource_api_version: V3
+  cds_config:
+    ads: {}
+    resource_api_version: V3
+
+static_resources:
+  listeners:
+  - name: envoy-gateway-proxy-ready-0.0.0.0-19001
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 19001
+        protocol: TCP
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          stat_prefix: eg-ready-http
+          route_config:
+            name: local_route
+          http_filters:
+          - name: envoy.filters.http.health_check
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+              pass_through_mode: false
+              headers:
+              - name: ":path"
+                string_match:
+                  exact: /ready
+          - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+  - name: xds_cluster
+    connect_timeout: 10s
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+      - load_balancing_weight: 1
+        lb_endpoints:
+        - load_balancing_weight: 1
+          endpoint:
+            address:
+              socket_address:
+                address: envoy-gateway
+                port_value: 18000
+    typed_extension_protocol_options:
+      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
+        explicit_http_config:
+          http2_protocol_options:
+            connection_keepalive:
+              interval: 30s
+              timeout: 5s
+overload_manager:
+  refresh_interval: 0.25s
+  resource_monitors:
+  - name: "envoy.resource_monitors.global_downstream_max_connections"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
+      max_active_downstream_connections: 50000
+  - name: "envoy.resource_monitors.fixed_heap"
+    typed_config:
+      "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
+      max_heap_size_bytes: 2147483648
+  actions:
+  - name: "envoy.overload_actions.shrink_heap"
+    triggers:
+    - name: "envoy.resource_monitors.fixed_heap"
+      threshold:
+        value: 0.95
+  - name: "envoy.overload_actions.stop_accepting_requests"
+    triggers:
+    - name: "envoy.resource_monitors.fixed_heap"
+      threshold:
+        value: 0.98

--- a/pkg/gateway/xds/bootstrap/testdata/render/overload-manager.yaml
+++ b/pkg/gateway/xds/bootstrap/testdata/render/overload-manager.yaml
@@ -3,31 +3,11 @@ admin:
   - name: envoy.access_loggers.file
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
-      path: {{ .AdminServer.AccessLogPath }}
+      path: /dev/null
   address:
     socket_address:
-      address: {{ .AdminServer.Address }}
-      port_value: {{ .AdminServer.Port }}
-{{- if .StatsMatcher  }}
-stats_config:
-  stats_matcher:
-    inclusion_list:
-      patterns:
-      {{- range $_, $item := .StatsMatcher.Exacts }}
-      - exact: {{$item}}
-      {{- end}}
-      {{- range $_, $item := .StatsMatcher.Prefixs }}
-      - prefix: {{$item}}
-      {{- end}}
-      {{- range $_, $item := .StatsMatcher.Suffixs }}
-      - suffix: {{$item}}
-      {{- end}}
-      {{- range $_, $item := .StatsMatcher.RegularExpressions }}
-      - safe_regex:
-          google_re2: {}
-          regex: {{js $item}}
-      {{- end}}
-{{- end }}
+      address: 127.0.0.1
+      port_value: 19000
 layered_runtime:
   layers:
   - name: global_config
@@ -50,25 +30,13 @@ dynamic_resources:
     ads: {}
     resource_api_version: V3
 
-{{- if .OtelMetricSinks }}
-stats_sinks:
-{{- range $idx, $sink := .OtelMetricSinks }}
-- name: "envoy.stat_sinks.open_telemetry"
-  typed_config:
-    "@type": type.googleapis.com/envoy.extensions.stat_sinks.open_telemetry.v3.SinkConfig
-    grpc_service:
-      envoy_grpc:
-        cluster_name: otel_metric_sink_{{ $idx }}
-{{- end }}
-{{- end }}
-
 static_resources:
   listeners:
-  - name: envoy-gateway-proxy-ready-{{ .ReadyServer.Address }}-{{ .ReadyServer.Port }}
+  - name: envoy-gateway-proxy-ready-0.0.0.0-19001
     address:
       socket_address:
-        address: {{ .ReadyServer.Address }}
-        port_value: {{ .ReadyServer.Port }}
+        address: 0.0.0.0
+        port_value: 19001
         protocol: TCP
     filter_chains:
     - filters:
@@ -78,17 +46,6 @@ static_resources:
           stat_prefix: eg-ready-http
           route_config:
             name: local_route
-            {{- if .EnablePrometheus }}
-            virtual_hosts:
-            - name: prometheus_stats
-              domains:
-              - "*"
-              routes:
-              - match:
-                  prefix: /stats/prometheus
-                route:
-                  cluster: prometheus_stats
-            {{- end }}
           http_filters:
           - name: envoy.filters.http.health_check
             typed_config:
@@ -97,46 +54,11 @@ static_resources:
               headers:
               - name: ":path"
                 string_match:
-                  exact: {{ .ReadyServer.ReadinessPath }}
+                  exact: /ready
           - name: envoy.filters.http.router
             typed_config:
               "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
-  {{- if .EnablePrometheus }}
-  - name: prometheus_stats
-    connect_timeout: 0.250s
-    type: STATIC
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: prometheus_stats
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: {{ .AdminServer.Address }}
-                port_value: {{ .AdminServer.Port }}
-  {{- end }}
-  {{- range $idx, $sink := .OtelMetricSinks }}
-  - name: otel_metric_sink_{{ $idx }}
-    connect_timeout: 0.250s
-    type: STRICT_DNS
-    typed_extension_protocol_options:
-      envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
-        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
-        explicit_http_config:
-          http2_protocol_options: {}
-    lb_policy: ROUND_ROBIN
-    load_assignment:
-      cluster_name: otel_metric_sink_{{ $idx }}
-      endpoints:
-      - lb_endpoints:
-        - endpoint:
-            address:
-              socket_address:
-                address: {{ $sink.Address }}
-                port_value: {{ $sink.Port }}
-  {{- end }}
   - name: xds_cluster
     connect_timeout: 10s
     type: STRICT_DNS
@@ -150,8 +72,8 @@ static_resources:
           endpoint:
             address:
               socket_address:
-                address: {{ .XdsServer.Address }}
-                port_value: {{ .XdsServer.Port }}
+                address: envoy-gateway
+                port_value: 18000
     typed_extension_protocol_options:
       envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions"
@@ -166,12 +88,11 @@ overload_manager:
   - name: "envoy.resource_monitors.global_downstream_max_connections"
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.resource_monitors.downstream_connections.v3.DownstreamConnectionsConfig
-      max_active_downstream_connections: {{ .OverloadManager.MaxActiveDownstreamConnections }}
-  {{- with .OverloadManager.MaxHeapSizeBytes }}
+      max_active_downstream_connections: 50000
   - name: "envoy.resource_monitors.fixed_heap"
     typed_config:
       "@type": type.googleapis.com/envoy.extensions.resource_monitors.fixed_heap.v3.FixedHeapConfig
-      max_heap_size_bytes: {{ . }}
+      max_heap_size_bytes: 1073741824
   actions:
   - name: "envoy.overload_actions.shrink_heap"
     triggers:
@@ -183,4 +104,3 @@ overload_manager:
     - name: "envoy.resource_monitors.fixed_heap"
       threshold:
         value: 0.98
-  {{- end }}


### PR DESCRIPTION
supports setting the max active connections + max heap size as flags on backplane.